### PR TITLE
Feature/home header

### DIFF
--- a/Starbucks-Texture/Starbucks-Texture.xcodeproj/project.pbxproj
+++ b/Starbucks-Texture/Starbucks-Texture.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		ED71D7CF27049325006347EC /* EditableTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED71D7CE27049325006347EC /* EditableTextField.swift */; };
 		EDB20AE52717D8A7001D647E /* CardMenuCellNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB20AE42717D8A7001D647E /* CardMenuCellNode.swift */; };
 		EDB6BC8D26FA438A00A5F64C /* DetailEmptyCellNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB6BC8C26FA438A00A5F64C /* DetailEmptyCellNode.swift */; };
+		EDD3117E273B7A32003E2469 /* HomeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3117D273B7A31003E2469 /* HomeController.swift */; };
 		EDF049F9270CC4B300C4B4B0 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF049F8270CC4B300C4B4B0 /* Card.swift */; };
 		EDF049FB270CC7FF00C4B4B0 /* DetailCardCellNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF049FA270CC7FF00C4B4B0 /* DetailCardCellNode.swift */; };
 		EDF04A03270CD56300C4B4B0 /* ChargeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF04A02270CD56300C4B4B0 /* ChargeButton.swift */; };
@@ -60,6 +61,7 @@
 		ED71D7CE27049325006347EC /* EditableTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableTextField.swift; sourceTree = "<group>"; };
 		EDB20AE42717D8A7001D647E /* CardMenuCellNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardMenuCellNode.swift; sourceTree = "<group>"; };
 		EDB6BC8C26FA438A00A5F64C /* DetailEmptyCellNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEmptyCellNode.swift; sourceTree = "<group>"; };
+		EDD3117D273B7A31003E2469 /* HomeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeController.swift; sourceTree = "<group>"; };
 		EDF049F8270CC4B300C4B4B0 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		EDF049FA270CC7FF00C4B4B0 /* DetailCardCellNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCardCellNode.swift; sourceTree = "<group>"; };
 		EDF04A02270CD56300C4B4B0 /* ChargeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargeButton.swift; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 			children = (
 				EDF049FE270CCC1100C4B4B0 /* Tabbar */,
 				ED71D7C727044959006347EC /* Pay */,
+				EDD3117C273B7A1F003E2469 /* Home */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -226,6 +229,14 @@
 				EDB20AE42717D8A7001D647E /* CardMenuCellNode.swift */,
 			);
 			path = CardDetail;
+			sourceTree = "<group>";
+		};
+		EDD3117C273B7A1F003E2469 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				EDD3117D273B7A31003E2469 /* HomeController.swift */,
+			);
+			path = Home;
 			sourceTree = "<group>";
 		};
 		EDF049F7270CC4A500C4B4B0 /* Models */ = {
@@ -433,6 +444,7 @@
 				ED63854426FA120F007F7F8D /* TabbarController.swift in Sources */,
 				ED71D7CD2704918A006347EC /* CardDetailCellNode.swift in Sources */,
 				ED20D6A7271693CA00005770 /* DetailCardController.swift in Sources */,
+				EDD3117E273B7A32003E2469 /* HomeController.swift in Sources */,
 				ED63854626FA1263007F7F8D /* PayController.swift in Sources */,
 				EDF049FB270CC7FF00C4B4B0 /* DetailCardCellNode.swift in Sources */,
 				ED63854D26FA2298007F7F8D /* NavigationController+.swift in Sources */,

--- a/Starbucks-Texture/Starbucks-Texture.xcodeproj/project.pbxproj
+++ b/Starbucks-Texture/Starbucks-Texture.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		EDB20AE52717D8A7001D647E /* CardMenuCellNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB20AE42717D8A7001D647E /* CardMenuCellNode.swift */; };
 		EDB6BC8D26FA438A00A5F64C /* DetailEmptyCellNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB6BC8C26FA438A00A5F64C /* DetailEmptyCellNode.swift */; };
 		EDD3117E273B7A32003E2469 /* HomeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3117D273B7A31003E2469 /* HomeController.swift */; };
+		EDD31180273BA17D003E2469 /* TopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3117F273BA17D003E2469 /* TopView.swift */; };
+		EDD31183273BBA42003E2469 /* ContentNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD31182273BBA42003E2469 /* ContentNode.swift */; };
 		EDF049F9270CC4B300C4B4B0 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF049F8270CC4B300C4B4B0 /* Card.swift */; };
 		EDF049FB270CC7FF00C4B4B0 /* DetailCardCellNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF049FA270CC7FF00C4B4B0 /* DetailCardCellNode.swift */; };
 		EDF04A03270CD56300C4B4B0 /* ChargeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF04A02270CD56300C4B4B0 /* ChargeButton.swift */; };
@@ -62,6 +64,8 @@
 		EDB20AE42717D8A7001D647E /* CardMenuCellNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardMenuCellNode.swift; sourceTree = "<group>"; };
 		EDB6BC8C26FA438A00A5F64C /* DetailEmptyCellNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEmptyCellNode.swift; sourceTree = "<group>"; };
 		EDD3117D273B7A31003E2469 /* HomeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeController.swift; sourceTree = "<group>"; };
+		EDD3117F273BA17D003E2469 /* TopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopView.swift; sourceTree = "<group>"; };
+		EDD31182273BBA42003E2469 /* ContentNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentNode.swift; sourceTree = "<group>"; };
 		EDF049F8270CC4B300C4B4B0 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		EDF049FA270CC7FF00C4B4B0 /* DetailCardCellNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCardCellNode.swift; sourceTree = "<group>"; };
 		EDF04A02270CD56300C4B4B0 /* ChargeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargeButton.swift; sourceTree = "<group>"; };
@@ -239,6 +243,15 @@
 			path = Home;
 			sourceTree = "<group>";
 		};
+		EDD31181273BA19A003E2469 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				EDD3117F273BA17D003E2469 /* TopView.swift */,
+				EDD31182273BBA42003E2469 /* ContentNode.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
 		EDF049F7270CC4A500C4B4B0 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -280,6 +293,7 @@
 		EDF049FF270CD52000C4B4B0 /* ComponentNodes */ = {
 			isa = PBXGroup;
 			children = (
+				EDD31181273BA19A003E2469 /* Home */,
 				EDF04A00270CD53A00C4B4B0 /* Pay */,
 			);
 			path = ComponentNodes;
@@ -425,9 +439,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED63852A26FA0E83007F7F8D /* AppDelegate.swift in Sources */,
+				EDD31180273BA17D003E2469 /* TopView.swift in Sources */,
 				EDF04A03270CD56300C4B4B0 /* ChargeButton.swift in Sources */,
 				ED71D7C527044127006347EC /* AddCardController.swift in Sources */,
 				EDB6BC8D26FA438A00A5F64C /* DetailEmptyCellNode.swift in Sources */,
+				EDD31183273BBA42003E2469 /* ContentNode.swift in Sources */,
 				ED20D6A427167B4D00005770 /* CardListCellNode.swift in Sources */,
 				EDF049F9270CC4B300C4B4B0 /* Card.swift in Sources */,
 				EDF04A27270D6A1400C4B4B0 /* ASCellNode+.swift in Sources */,

--- a/Starbucks-Texture/Starbucks-Texture/Sources/ComponentNodes/Home/ContentNode.swift
+++ b/Starbucks-Texture/Starbucks-Texture/Sources/ComponentNodes/Home/ContentNode.swift
@@ -1,0 +1,163 @@
+//
+//  ContentNode.swift
+//  Starbucks-Texture
+//
+//  Created by SHIN YOON AH on 2021/11/10.
+//
+
+import AsyncDisplayKit
+import Then
+
+final class ContentNode: ASDisplayNode {
+    
+    // MARK: - Section
+    enum Section: Int, CaseIterable {
+        case card
+        case coupon
+        case advertise
+    }
+    
+    // MARK: - UI
+    private lazy var tableNode = ASTableNode().then {
+        $0.dataSource = self
+        $0.delegate = self
+        $0.view.separatorStyle = .none
+        $0.view.showsVerticalScrollIndicator = true
+        $0.backgroundColor = .white
+    }
+    private var topNode = TopView().then {
+        $0.backgroundColor = .systemBlue
+        $0.styled {
+            $0.height = ASDimension(unit: .points, value: 230)
+        }
+    }
+    
+    // MARK: - Properties
+    
+    private var didScroll: Bool = false
+    private var ratio: CGFloat = 0.3
+    
+    // MARK: - Initalizing
+    override init() {
+        super.init()
+        self.automaticallyManagesSubnodes = true
+        self.automaticallyRelayoutOnSafeAreaChanges = true
+    }
+    
+    // MARK: - Override Method
+    override func animateLayoutTransition(_ context: ASContextTransitioning) {
+        let beforeFrame = context.initialFrame(for: topNode)
+        
+        let afterFrame = context.finalFrame(for: topNode)
+        topNode.frame = beforeFrame
+        topNode.alpha = 1.0
+        UIView.animate(withDuration: 0.0,
+                       delay: 0.0,
+                       options: .allowAnimatedContent,
+                       animations: {
+            self.topNode.frame = afterFrame
+            self.topNode.alpha = 0.0
+        }, completion: {
+            context.completeTransition($0)
+        })
+    }
+    
+    // MARK: - Custom Method
+    private func setRatio(_ ratio: CGFloat) {
+        self.ratio = ratio
+        self.transitionLayout(withAnimation: true,
+                              shouldMeasureAsync: true,
+                              measurementCompletion: nil)
+    }
+    
+    // MARK: - Layout
+    override func layout() {
+        super.layout()
+    }
+    
+    override func layoutSpecThatFits(_ constraintedSize: ASSizeRange) -> ASLayoutSpec {
+        topNode.style.flexBasis = .init(unit: .fraction, value: ratio)
+        tableNode.style.flexBasis = .init(unit: .fraction, value: 1.0 - ratio)
+        
+        let contentLayout = ASStackLayoutSpec (
+            direction: .vertical,
+            spacing: 0.0,
+            justifyContent: .start,
+            alignItems: .stretch,
+            children: [
+                topNode,
+                tableNode
+            ]
+        )
+
+        return contentLayout
+    }
+}
+
+// MARK: - ASTableDataSource
+extension ContentNode: ASTableDataSource {
+    func tableNode(_ tableNode: ASTableNode, numberOfRowsInSection section: Int) -> Int {
+        return 3
+    }
+    
+    func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
+        return {
+            guard let section = Section.init(rawValue: indexPath.row) else { return ASCellNode() }
+            
+            switch section {
+            case .card:
+                let cardCellNode = CardCellNode()
+                return cardCellNode
+            case .coupon:
+                guard CardCellNode.cards.count > 0 else { return ASCellNode() }
+                
+                return CouponCellNode()
+            case .advertise:
+                return AdCellNode()
+            }
+        }
+    }
+
+    func tableNode(_ tableNode: ASTableNode, constrainedSizeForRowAt indexPath: IndexPath) -> ASSizeRange {
+        guard let section = Section.init(rawValue: indexPath.row) else { return ASSizeRange() }
+        switch section {
+        case .card:
+            return ASSizeRange(min: .zero, max: .init(width: self.view.frame.width, height: 600))
+        case .coupon:
+            guard CardCellNode.cards.count > 0 else { return ASSizeRange(min: .zero, max: .init(width: self.view.frame.width, height: 0)) }
+            
+            return ASSizeRange(min: .zero, max: .init(width: self.view.frame.width, height: 70))
+        case .advertise:
+            return ASSizeRange(min: .zero, max: .init(width: self.view.frame.width, height: 70))
+        }
+    }
+
+    func tableNode(_ tableNode: ASTableNode, willDisplayRowWith node: ASCellNode) {
+        node.backgroundColor = .white
+    }
+}
+
+extension ContentNode: ASTableDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let offset = scrollView.contentOffset.y
+        
+        if offset > 0 && !didScroll {
+            didScroll = true
+            UIView.animate(withDuration: 0.2,
+                           delay: 0.0,
+                           options: .curveEaseOut,
+                           animations: {
+                self.topNode.transform = CATransform3DTranslate(self.topNode.transform, 0, -230, 0)
+                self.tableNode.transform = CATransform3DTranslate(self.topNode.transform, 0, -230, 0)
+            }, completion: { _ in
+                self.setRatio(0.0)
+            })
+        }
+        
+        if offset == 0 {
+            didScroll = false
+        }
+        
+//        if offset < 0 && !didScroll
+    }
+}

--- a/Starbucks-Texture/Starbucks-Texture/Sources/ComponentNodes/Home/TopView.swift
+++ b/Starbucks-Texture/Starbucks-Texture/Sources/ComponentNodes/Home/TopView.swift
@@ -1,0 +1,67 @@
+//
+//  TopView.swift
+//  Starbucks-Texture
+//
+//  Created by SHIN YOON AH on 2021/11/10.
+//
+
+import AsyncDisplayKit
+import QuartzCore
+
+final class TopView: ASDisplayNode {
+    // MARK: - Const
+    struct Const {
+        static var titleAttribute: [NSAttributedString.Key: Any] {
+            return [.font: UIFont.systemFont(ofSize: 28.0, weight: .semibold),
+                    .foregroundColor: UIColor.black]
+        }
+    }
+    
+    // MARK: - UI
+    private var headerTitleNode = ASTextNode().then {
+        $0.maximumNumberOfLines = 2
+        $0.attributedText = NSAttributedString(string: "환절기 따뜻한 차로\n수분 충전하세요☕️", attributes: Const.titleAttribute)
+    }
+    
+    // MARK: - Initalizing
+    override init() {
+        super.init()
+        self.automaticallyManagesSubnodes = true
+        self.automaticallyRelayoutOnSafeAreaChanges = true
+    }
+    
+    // MARK: - Override Method
+    override func animateLayoutTransition(_ context: ASContextTransitioning) {
+        let beforeFrame = context.initialFrame(for: headerTitleNode)
+        
+        let afterFrame = context.finalFrame(for: headerTitleNode)
+        headerTitleNode.frame = beforeFrame
+        headerTitleNode.alpha = 1.0
+        UIView.animate(withDuration: 0.1,
+                       delay: 0.0,
+                       options: .curveEaseOut,
+                       animations: {
+            self.headerTitleNode.frame = afterFrame
+            self.headerTitleNode.alpha = 0.0
+            self.headerTitleNode.transform = CATransform3DTranslate(self.headerTitleNode.transform, 0, -200, 0)
+        }, completion: {
+            context.completeTransition($0)
+        })
+    }
+    
+    // MARK: - Layout
+    override func layout() {
+        super.layout()
+    }
+    
+    override func layoutSpecThatFits(_ constraintedSize: ASSizeRange) -> ASLayoutSpec {
+        return contentInsetLayoutSpec()
+    }
+    
+    private func contentInsetLayoutSpec() -> ASLayoutSpec {
+        return ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 100, left: 20, bottom: 0, right: 0),
+            child: headerTitleNode
+        )
+    }
+}

--- a/Starbucks-Texture/Starbucks-Texture/Sources/ViewControllers/Home/HomeController.swift
+++ b/Starbucks-Texture/Starbucks-Texture/Sources/ViewControllers/Home/HomeController.swift
@@ -6,30 +6,16 @@
 //
 
 import AsyncDisplayKit
+import Then
 
-final class HomeController: ASDKViewController<ASDisplayNode> {
-    // MARK: - Section
-    enum Section: Int, CaseIterable {
-        case card
-        case coupon
-        case advertise
-    }
-    
-    // MARK: - UI
-    private lazy var tableNode = ASTableNode().then {
-        $0.dataSource = self
-        $0.backgroundColor = .white
-    }
+final class HomeController: ASDKViewController<ContentNode> {
     
     // MARK: - Initializing
     override init() {
-        super.init(node: .init())
+        super.init(node: ContentNode.init())
         self.node.backgroundColor = .white
         self.node.automaticallyManagesSubnodes = true
         self.node.automaticallyRelayoutOnSafeAreaChanges = true
-        self.node.layoutSpecBlock = { [weak self] (node, constraintedSize) -> ASLayoutSpec in
-            return self?.layoutSpecThatFits(constraintedSize) ?? ASLayoutSpec()
-        }
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -38,82 +24,11 @@ final class HomeController: ASDKViewController<ASDisplayNode> {
     
     // MARK: - Life Cycle
     override func viewDidLoad() {
-        tableNode.view.separatorStyle = .none
-        tableNode.view.showsVerticalScrollIndicator = true
         setupNavigationController()
     }
     
     // MARK: - Custom Method
     private func setupNavigationController() {
         navigationController?.isNavigationBarHidden = true
-    }
-    
-    // MARK: - @objc
-    @objc
-    private func touchUpCardList() {
-        let vc = CardListController()
-        vc.hidesBottomBarWhenPushed = true
-        navigationController?.pushViewController(vc, animated: true)
-    }
-    
-    // MARK: - Layout
-    private func layoutSpecThatFits(_ constraintedSize: ASSizeRange) -> ASLayoutSpec {
-        let contentLayout = ASStackLayoutSpec (
-            direction: .vertical,
-            spacing: 0.0,
-            justifyContent: .start,
-            alignItems: .stretch,
-            children: [
-                tableNode.styled({
-                    $0.flexGrow = 1.0
-                })
-            ]
-        )
-        let safeAreaInset: UIEdgeInsets = self.view.safeAreaInsets
-        return ASInsetLayoutSpec (
-            insets: safeAreaInset, child: contentLayout)
-    }
-}
-
-// MARK: - ASTableDataSource
-extension HomeController: ASTableDataSource {
-    func tableNode(_ tableNode: ASTableNode, numberOfRowsInSection section: Int) -> Int {
-        return 3
-    }
-    
-    func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
-        return {
-            guard let section = Section.init(rawValue: indexPath.row) else { return ASCellNode() }
-            
-            switch section {
-            case .card:
-                let cardCellNode = CardCellNode()
-                return cardCellNode
-            case .coupon:
-                guard CardCellNode.cards.count > 0 else { return ASCellNode() }
-                
-                return CouponCellNode()
-            case .advertise:
-                return AdCellNode()
-            }
-        }
-    }
-
-    func tableNode(_ tableNode: ASTableNode, constrainedSizeForRowAt indexPath: IndexPath) -> ASSizeRange {
-        guard let section = Section.init(rawValue: indexPath.row) else { return ASSizeRange() }
-        switch section {
-        case .card:
-            return ASSizeRange(min: .zero, max: .init(width: self.view.frame.width, height: 600))
-        case .coupon:
-            guard CardCellNode.cards.count > 0 else { return ASSizeRange(min: .zero, max: .init(width: self.view.frame.width, height: 0)) }
-            
-            return ASSizeRange(min: .zero, max: .init(width: self.view.frame.width, height: 70))
-        case .advertise:
-            return ASSizeRange(min: .zero, max: .init(width: self.view.frame.width, height: 70))
-        }
-    }
-
-    func tableNode(_ tableNode: ASTableNode, willDisplayRowWith node: ASCellNode) {
-        node.backgroundColor = .white
     }
 }

--- a/Starbucks-Texture/Starbucks-Texture/Sources/ViewControllers/Home/HomeController.swift
+++ b/Starbucks-Texture/Starbucks-Texture/Sources/ViewControllers/Home/HomeController.swift
@@ -1,20 +1,13 @@
 //
-//  PayController.swift
+//  HomeController.swift
 //  Starbucks-Texture
 //
-//  Created by SHIN YOON AH on 2021/09/21.
+//  Created by SHIN YOON AH on 2021/11/10.
 //
 
 import AsyncDisplayKit
-import Then
 
-// MARK: - Protocol CardDelegate
-protocol CardDelegate: PayController {
-    func emptyCardClickedToPresent(_ viewController: AddCardController)
-    func cardClickedToPresent(_ viewController: DetailCardController)
-}
-
-final class PayController: ASDKViewController<ASDisplayNode> {
+final class HomeController: ASDKViewController<ASDisplayNode> {
     // MARK: - Section
     enum Section: Int, CaseIterable {
         case card
@@ -26,11 +19,6 @@ final class PayController: ASDKViewController<ASDisplayNode> {
     private lazy var tableNode = ASTableNode().then {
         $0.dataSource = self
         $0.backgroundColor = .white
-    }
-    private lazy var detailButton = UIButton().then {
-        $0.setImage(UIImage(systemName: "list.bullet"), for: .normal)
-        $0.setPreferredSymbolConfiguration(.init(pointSize: 17, weight: .regular, scale: .large), forImageIn: .normal)
-        $0.tintColor = .lightGray
     }
     
     // MARK: - Initializing
@@ -52,21 +40,12 @@ final class PayController: ASDKViewController<ASDisplayNode> {
     override func viewDidLoad() {
         tableNode.view.separatorStyle = .none
         tableNode.view.showsVerticalScrollIndicator = true
-        detailButton.addTarget(self, action: #selector(touchUpCardList), for: .touchUpInside)
         setupNavigationController()
     }
     
     // MARK: - Custom Method
     private func setupNavigationController() {
-        navigationController?.navigationBar.barTintColor = .white
-        navigationController?.navigationBar.shadowImage = UIImage()
-        navigationController?.navigationBar.layer.applyShadow(color: .gray, alpha: 0.3, x: 0, y: 0, blur: 12)
-        navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.largeTitleDisplayMode = .automatic
-        navigationItem.title = "Pay"
-        
-        let barButton = UIBarButtonItem(customView: detailButton)
-        navigationItem.rightBarButtonItem = barButton
+        navigationController?.isNavigationBarHidden = true
     }
     
     // MARK: - @objc
@@ -97,7 +76,7 @@ final class PayController: ASDKViewController<ASDisplayNode> {
 }
 
 // MARK: - ASTableDataSource
-extension PayController: ASTableDataSource {
+extension HomeController: ASTableDataSource {
     func tableNode(_ tableNode: ASTableNode, numberOfRowsInSection section: Int) -> Int {
         return 3
     }
@@ -109,7 +88,6 @@ extension PayController: ASTableDataSource {
             switch section {
             case .card:
                 let cardCellNode = CardCellNode()
-                cardCellNode.delegate = self
                 return cardCellNode
             case .coupon:
                 guard CardCellNode.cards.count > 0 else { return ASCellNode() }
@@ -137,25 +115,5 @@ extension PayController: ASTableDataSource {
 
     func tableNode(_ tableNode: ASTableNode, willDisplayRowWith node: ASCellNode) {
         node.backgroundColor = .white
-    }
-}
-
-// MARK: - CardDelegate
-extension PayController: CardDelegate {
-    func cardClickedToPresent(_ viewController: DetailCardController) {
-        viewController.hidesBottomBarWhenPushed = true
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-    
-    func emptyCardClickedToPresent(_ viewController: AddCardController) {
-        viewController.addCard = {
-            CardCellNode.cards.append(contentsOf: [
-                Card(cardImage: "thankyou", name: "Thank You 카드", balance: "2,300원", code: "****-****-**36-6582"),
-                Card(cardImage: "limited", name: "Limited 카드", balance: "102,300원", code: "****-****-**70-7431")]
-            )
-            self.tableNode.reloadData()
-        }
-        viewController.hidesBottomBarWhenPushed = true
-        navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Starbucks-Texture/Starbucks-Texture/Sources/ViewControllers/Tabbar/TabbarController.swift
+++ b/Starbucks-Texture/Starbucks-Texture/Sources/ViewControllers/Tabbar/TabbarController.swift
@@ -25,7 +25,8 @@ class TabbarController: UITabBarController {
     }
     
     private func setupTabs(){
-        let homeTab = PayController()
+        let homeNavi = UINavigationController(rootViewController: HomeController())
+        let homeTab = homeNavi
         homeTab.tabBarItem = UITabBarItem(title: "Home", image: UIImage(systemName: "house.fill"), tag: 0)
         
         let payNavi = UINavigationController(rootViewController: PayController())
@@ -44,6 +45,6 @@ class TabbarController: UITabBarController {
         let tabs =  [homeTab, payTab, orderTab, giftTab, otherTab]
         
         self.setViewControllers(tabs, animated: false)
-        self.selectedViewController = payTab
+        self.selectedViewController = homeTab
     }
 }


### PR DESCRIPTION
<!-- Linked issues -->
TexBrother/TexBrother-Yoonah#7
<!-- EXAMPLE ->
<!-- TexBrother/TexBrother-Hansol#1 -->

## Summary
Home뷰에서 Scroll했을 때 상단뷰가 올라가는 애니메이션을 구현했습니다.
원래 올라가는 부분이 Scroll에 따라서 Layout이 바뀌는 것 같은데 AsyncDisplayKit에서는 어떻게 구현해야 할 지 모르겠어서
일단 애니메이션으로 구현했습니다.

더 좋은 방식을 계속해서 찾을 예정입니다🥲

## Sth Coming Newly
Layout Transition 방식을 알게됐습니다.

## Challenges
Layout Transition은 ASDisplayNode 안에서만 구현이 가능하고 `animateLayoutTransition`함수를 override해서 사용합니다.
```swift
 override func animateLayoutTransition(_ context: ASContextTransitioning) {
        let beforeFrame = context.initialFrame(for: topNode)
        
        let afterFrame = context.finalFrame(for: topNode)
        topNode.frame = beforeFrame
        topNode.alpha = scrollToTop ? 1.0 : 0.0
        UIView.animate(withDuration: scrollToTop ? 0.0 : 0.2,
                       delay: 0.0,
                       options: .allowAnimatedContent,
                       animations: {
            self.topNode.frame = afterFrame
            self.topNode.alpha = self.scrollToTop ? 0.0 : 1.0
        }, completion: {
            context.completeTransition($0)
        })
    }
```

해당 함수 안에 있는 부분을 
```swift
self.transitionLayout(withAnimation: true,
                              shouldMeasureAsync: true,
                              measurementCompletion: nil)
```
를 사용해서 Layout를 변경할 수 있습니다.

## References
<!-- 관련 자료가 있을 경우 첨부 및 링크 추가 -->
https://texture-kr.gitbook.io/wiki/layout-api/layout-transition-api
